### PR TITLE
Luke/search bar g maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6432,6 +6432,11 @@
         }
       }
     },
+    "google-maps-react": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/google-maps-react/-/google-maps-react-2.0.6.tgz",
+      "integrity": "sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ=="
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "bootstrap": "^4.5.3",
+    "google-maps-react": "^2.0.6",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,8 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="The best online marketplace for some handy help." />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDSIPccLtsIYbSuoI7_bs3RECC2nlbu30Q&libraries=places">
+  </script>
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/client/MakeListingModal.js
+++ b/src/components/client/MakeListingModal.js
@@ -20,7 +20,9 @@ const MakeListingModal = () => {
                 <Modal.Header closeButton>
                     <Modal.Title>Enter Listing Info</Modal.Title>
                 </Modal.Header>
-                <Modal.Body>Make listing form</Modal.Body>
+                <Modal.Body>
+                    Make listing form
+                    </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={handleClose}>
                         Close

--- a/src/components/pages/HomePage.js
+++ b/src/components/pages/HomePage.js
@@ -1,9 +1,22 @@
-import React from "react";
+import React, { useState } from "react";
+
+import GeoSearchBar from "../search/GeoSearchBar";
 
 const HomePage = () => {
+    const [coordinates, setCoordinates] = useState([null, null]);
+
+    function handleCoordinates(lat, lng) {
+        setCoordinates([lat, lng]);
+    }
+
     return (
         <div>
             <h1>HomePage component</h1>
+            <GeoSearchBar handleCoordinates={handleCoordinates} />
+            <div style={{ paddingTop: "10px" }}>
+                <p>Latitude: {coordinates[0]}</p>
+                <p>Longitude: {coordinates[1]}</p>
+            </div>
         </div>
     );
 }

--- a/src/components/search/GeoSearchBar.js
+++ b/src/components/search/GeoSearchBar.js
@@ -41,6 +41,7 @@ const GeoSearchBar = ({ handleCoordinates }) => {
 
     function getCoordinates() {
         // Get the place details from the autocomplete object.
+        console.log("wadup");
         const place = autocomplete.getPlace();
         const lat = place.geometry.location.lat();
         const lng = place.geometry.location.lng();
@@ -63,7 +64,6 @@ const GeoSearchBar = ({ handleCoordinates }) => {
                         center: geolocation,
                         radius: position.coords.accuracy,
                     });
-                    console.log("before it all breaks: ", autocomplete);
                     autocomplete.setBounds(circle.getBounds());
                 });
             }
@@ -77,13 +77,16 @@ const GeoSearchBar = ({ handleCoordinates }) => {
                 navigator.geolocation.getCurrentPosition((position) => {
                     const lat = position.coords.latitude;
                     const lng = position.coords.longitude;
-                    console.log("hi");
                     handleCoordinates(lat, lng);
                 }
                 )
             }
         }
         setChecked(!checked);
+    }
+
+    function sendEmptyCoordinates() {
+        handleCoordinates(null, null);
     }
 
     return (
@@ -96,6 +99,7 @@ const GeoSearchBar = ({ handleCoordinates }) => {
                 type="text"
                 ref={autocompleteRef}
                 disabled={checked}
+                onChange={() => sendEmptyCoordinates()}
             />
 
             <Form.Check label="Use current location" style={{ paddingTop: "5px" }} type="checkbox" checked={checked} onClick={() => handleCheck()} />

--- a/src/components/search/GeoSearchBar.js
+++ b/src/components/search/GeoSearchBar.js
@@ -1,0 +1,106 @@
+//https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
+//https://react-bootstrap.netlify.app/components/forms/#forms
+
+import React, { useEffect, useRef, useState } from "react";
+
+import { Form } from "react-bootstrap";
+
+
+// PARENT MUST PROVIDE A handleCoordinates CALLBACK
+//
+// Define in parent:
+/* 
+    function handleCoordinates(lat, lng){
+        do stuff with lat, lng returned from GeoSearchBar
+    }
+*/
+
+//  Dont forget to pass the function to this component:
+/*
+    return(
+        <GeoSearchBar handleCoordinates={handleCoordinates}/>
+    )
+*/
+
+const GeoSearchBar = ({ handleCoordinates }) => {
+    let autocompleteRef = useRef();
+    const G = window.google.maps;
+    let autocomplete;
+    const [checked, setChecked] = useState(false);
+
+    useEffect(() => {
+        initAutocomplete();
+    }, [])
+
+
+    function initAutocomplete() {
+        autocomplete = new G.places.Autocomplete(autocompleteRef.current, { types: ["geocode"] });
+        autocomplete.setFields(["geometry"]);
+        autocomplete.addListener("place_changed", getCoordinates);
+    }
+
+    function getCoordinates() {
+        // Get the place details from the autocomplete object.
+        const place = autocomplete.getPlace();
+        const lat = place.geometry.location.lat();
+        const lng = place.geometry.location.lng();
+
+        //callback function --> pass lat, lng back to parent. 
+        handleCoordinates(lat, lng);
+    }
+
+    // Bias the autocomplete object to the user's geographical location,
+    // as supplied by the browser's 'navigator.geolocation' object.
+    function geolocate() {
+        if (autocomplete) {
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition((position) => {
+                    const geolocation = {
+                        lat: position.coords.latitude,
+                        lng: position.coords.longitude,
+                    };
+                    const circle = new G.Circle({
+                        center: geolocation,
+                        radius: position.coords.accuracy,
+                    });
+                    console.log("before it all breaks: ", autocomplete);
+                    autocomplete.setBounds(circle.getBounds());
+                });
+            }
+        }
+    }
+
+    function handleCheck() {
+        //user selects to use current location
+        if (!checked) {
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition((position) => {
+                    const lat = position.coords.latitude;
+                    const lng = position.coords.longitude;
+                    console.log("hi");
+                    handleCoordinates(lat, lng);
+                }
+                )
+            }
+        }
+        setChecked(!checked);
+    }
+
+    return (
+        <div id="locationField" style={{ display: "flex", flexDirection: "column", padding: "5px" }}>
+            <Form.Label>Enter your location</Form.Label>
+            <Form.Control as="input"
+                id="autocomplete"
+                placeholder="Ex: Santa Barbara, CA"
+                onFocus={geolocate()}
+                type="text"
+                ref={autocompleteRef}
+                disabled={checked}
+            />
+
+            <Form.Check label="Use current location" style={{ paddingTop: "5px" }} type="checkbox" checked={checked} onClick={() => handleCheck()} />
+        </div>
+    )
+}
+
+export default GeoSearchBar;

--- a/src/index.css
+++ b/src/index.css
@@ -63,18 +63,6 @@ html {
   margin: 3px 3px;
 }
 
-#map {
-  height: 100%;
-}
-
-/* Optional: Makes the sample page fill the window. */
-html,
-body {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-}
-
 
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,20 @@ html {
 .sign-button{
   margin: 3px 3px;
 }
+
+#map {
+  height: 100%;
+}
+
+/* Optional: Makes the sample page fill the window. */
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+
+
+
+


### PR DESCRIPTION
Test 1 (Success): 
If I type a location on the search bar, it should provide autocomplete options. When I select one of those options, the latitude and longitude should be passed via handleCoordinates callback.

Test 2 (Failure):
If I have not selected an autocomplete option, the handleCoordinates callback should be passing back null latitudes and longitudes.